### PR TITLE
use xstream

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "es2015",
+		"react-native"
+	]
+}

--- a/common.js
+++ b/common.js
@@ -1,5 +1,4 @@
-import {run} from '@cycle/core';
-import {Rx} from 'rx';
+import xs from 'xstream';
 import React from 'react-native';
 import makeReactNativeDriver, {getBackHandler} from '@cycle/react-native/src/driver';
 import Touchable from '@cycle/react-native/src/Touchable';
@@ -35,7 +34,7 @@ const {
 } = Touchable;
 
 export function main({RN, HTTP}) {
-  let request$ = Rx.Observable.just({url: URL});
+  let request$ = xs.of({url: URL});
   return {
     RN: model(intent(RN, HTTP)).map(view),
     HTTP: request$
@@ -95,7 +94,7 @@ function model({increment, response, goToSecondView, back}) {
     .startWith({data: {}})
     .map(({data}) => data);
 
-  const navigationState = Rx.Observable.merge(goToSecondView, back)
+  const navigationState = xs.merge(goToSecondView, back)
     .startWith(initialNavigationState)
     .scan((prevState, action) => {
       return action.type === 'back'
@@ -103,7 +102,7 @@ function model({increment, response, goToSecondView, back}) {
         : NavigationStateUtils.push(prevState, action)
     })
 
-  return Rx.Observable.combineLatest(counter, response, navigationState, selectedProfile,
+  return xs.combine(counter, response, navigationState, selectedProfile,
     (counter, response, navigationState, selectedProfile) => ({
       counter,
       response,

--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
-import {run} from '@cycle/core';
+import {run} from '@cycle/xstream-run';
 import makeReactNativeDriver from '@cycle/react-native/src/driver';
 import {makeHTTPDriver} from '@cycle/http';
 import {main} from './common'

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,4 @@
-import {run} from '@cycle/core';
+import {run} from '@cycle/xstream-run';
 import makeReactNativeDriver from '@cycle/react-native/src/driver';
 import {makeHTTPDriver} from '@cycle/http';
 import {main} from './common'

--- a/package.json
+++ b/package.json
@@ -3,14 +3,20 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "BABEL_DISABLE_CACHE=1 node_modules/react-native/packager/packager.sh --reset-cache"
   },
   "dependencies": {
-    "@cycle/core": "^6.0.3",
+    "@cycle/xstream-run": "1.0.0",
     "@cycle/http": "8.2.2",
     "@cycle/react-native": "git@github.com:jevakallio/cycle-react-native.git#master",
     "react": "0.14.8",
     "react-native": "^0.24.0",
-    "rx": "^4.1.0"
+    "xstream": "1.0.x"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.7.7",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react-native": "^1.5.7",
+    "babel-preset-react-native-stage-0": "^1.0.1"
   }
 }


### PR DESCRIPTION
Note: This pull request is incompleted due issues with babel presets.

After running the app the simulator shows errors such as `TypeError: babelHelpers.typeof is not a function`.

It seems that `xstream-run` needs preset of `es-2015` (https://github.com/cyclejs/xstream-run/blob/master/.babelrc). After adding it add to `.babelrc` as the [hello-world example it does](https://github.com/cyclejs/examples/blob/diversity/hello-world/.babelrc) I run into the error described above. To fix it a preset of `react-native-stage-0` seems to be needed as described here https://github.com/facebook/react-native/issues/5747#issuecomment-204037630 But after that the same error it causes by Cycle now... :(

Any ideas to fix it?
